### PR TITLE
Fix Wikirim perfomance at large search result: limit maximum count of displayed entries

### DIFF
--- a/Source/HelpTab/HelpTab/MainTabWindow_ModHelp.cs
+++ b/Source/HelpTab/HelpTab/MainTabWindow_ModHelp.cs
@@ -337,8 +337,15 @@ namespace HelpTab
             GUI.EndGroup();
         }
 
+        // Maximum count of displayed entries.
+        // It added to improve perfomance at large search result.
+        private const int MaxEntryCount = 200;
+
+        private int entryCounter = 0;
+
         void DrawSelectionArea(Rect rect)
         {
+            entryCounter = 0;
             Widgets.DrawMenuSection(rect);
 
             _filterUpdate();
@@ -394,6 +401,8 @@ namespace HelpTab
                                 foreach (HelpDef hd in hc.HelpDefs.Where(hd => hd.ShouldDraw))
                                 {
                                     DrawHelpEntry(ref cur, 1, viewRect, hd);
+                                    if (entryCounter >= MaxEntryCount)
+                                        break;
                                 }
                             }
                         }
@@ -430,6 +439,7 @@ namespace HelpTab
         /// <returns></returns>
         public bool DrawEntry(ref Vector2 cur, int nestLevel, Rect view, string label, State state, bool selected = false)
         {
+            this.entryCounter++;
             cur.x = nestLevel * EntryIndent;
             float iconOffset = ArrowImageSize.x + 2 * WindowMargin;
             float width = view.width - cur.x - iconOffset - WindowMargin;


### PR DESCRIPTION
Wikirim has very poor performance when using a single character search string.
It occurs when player adds a lot of mods, or when player uses mod pack (like HardcoreSK).

This PR limits the maximum count of displayed entries to 200.
This is a reasonable compromiss, where TPS is not decreasing. At the same time, a two-character search string almost always gives less than 200 entries.

[Related PR](https://github.com/skyarkhangel/Hardcore-SK/pull/2691)