### PR TITLE
FIX: humanoids without LeatherAmount set will not have a help page.

### DIFF
--- a/Source/HelpTab/HelpTab/HelpBuilder.cs
+++ b/Source/HelpTab/HelpTab/HelpBuilder.cs
@@ -1922,8 +1922,12 @@ namespace HelpTab
 
                 if (race.leatherDef != null)
                 {
-                    defs.Add(race.leatherDef);
-                    prefixes.Add("~" + (maxSize * raceDef.statBases.Find(sb => sb.stat == StatDefOf.LeatherAmount).value));
+                    StatModifier statModifier = raceDef.statBases.Find(sb => sb.stat == StatDefOf.LeatherAmount);
+                    if (statModifier != null)
+                    {
+                        defs.Add(race.leatherDef);
+                        prefixes.Add("~" + (maxSize * statModifier.value));
+                    }
                 }
 
                 statParts.Add(new HelpDetailSection(ResourceBank.String.AutoHelpListButcher, defs, prefixes.ToArray()));


### PR DESCRIPTION
I've stumbled upon a few warnings in the log files when playing with the [Monstergirl Races](https://steamcommunity.com/sharedfiles/filedetails/?id=1992614103) mod when trying to find out why they don't have a help page:

```
HelpTab :: Failed to build help for: MG_Dragon
	System.NullReferenceException: Object reference not set to an instance of an object
  at HelpTab.HelpBuilder.HelpPartsForHumanoid (Verse.ThingDef raceDef, System.Collections.Generic.List`1[HelpTab.HelpDetailSection]& statParts, System.Collections.Generic.List`1[HelpTab.HelpDetailSection]& linkParts) [0x005fd] in <53b2c234b24a4944b9fd513b10ddcac8>:0 
  at HelpTab.HelpBuilder.HelpForHumanoid (Verse.ThingDef def, HelpTab.HelpCategoryDef category) [0x000fb] in <53b2c234b24a4944b9fd513b10ddcac8>:0 
  at HelpTab.HelpBuilder.HelpForDef[T] (T def, HelpTab.HelpCategoryDef category) [0x00016] in <53b2c234b24a4944b9fd513b10ddcac8>:0 
  at HelpTab.HelpBuilder.ResolveDefList[T] (System.Collections.Generic.IEnumerable`1[T] defs, HelpTab.HelpCategoryDef category) [0x0005a] in <53b2c234b24a4944b9fd513b10ddcac8>:0 
```

This is due to the defs of the races in this mod not having the LeatherAmount defined.

This pull request seeks to fix that by only adding the leather amount if the humanoidDef in question has a stat for that.